### PR TITLE
Add reference to Org Setup page.

### DIFF
--- a/app/elements/shokka-drawer-admin-content/shokka-drawer-admin-content.html
+++ b/app/elements/shokka-drawer-admin-content/shokka-drawer-admin-content.html
@@ -13,6 +13,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <dom-module id="shokka-drawer-admin-content">
   <template>
     <p><a href='/users'> Users </a></p>
+    <p><a href='/'> Org Setup </a></p>
   </template>
   <script>
   (function() {


### PR DESCRIPTION
Minor fix to allow admin access to Org Setup page from anywhere on the site. Will need to update the href to location of org setup page if page changes from home screen to another location.
